### PR TITLE
pre-run prefix to object keys

### DIFF
--- a/src/sibench/main.go
+++ b/src/sibench/main.go
@@ -8,6 +8,7 @@ import "github.com/docopt/docopt-go"
 import "fmt"
 import "logger"
 import "math"
+import "math/rand"
 import "os"
 import "regexp"
 import "strings"
@@ -324,6 +325,15 @@ func startServer(args *Arguments) {
 }
 
 
+
+/* Creates a random string which we can use to guarantee uniqueness across runs. */
+func createUniquePrefix() string {
+    source := rand.NewSource(time.Now().UnixNano())
+    prng := rand.New(source)
+    return fmt.Sprintf("sibench-%X", prng.Uint64())
+}
+
+
 /* Create a job and execute it on some set of servers. */
 func startRun(args *Arguments) {
     var j Job
@@ -338,6 +348,7 @@ func startRun(args *Arguments) {
     j.useBytes = args.UseBytes
 
     j.order.JobId = 1
+    j.order.ObjectKeyPrefix = createUniquePrefix()
     j.order.ObjectSize = args.ObjectSizeInBits
     j.order.Seed = uint64(time.Now().Unix())
     j.order.RangeStart = 0
@@ -394,7 +405,8 @@ func startRun(args *Arguments) {
                 "username": args.CephUser,
                 "key": args.CephKey,
                 "pool": args.CephPool,
-                "datapool": args.CephDatapool }
+                "datapool": args.CephDatapool,
+                "image_prefix": createUniquePrefix() }
 
         case args.Block:
             j.order.ConnectionType = "block"

--- a/src/sibench/messages.go
+++ b/src/sibench/messages.go
@@ -166,6 +166,7 @@ type WorkOrder struct {
     ReadWriteMix uint64             // Give the percentage of reads vs writes for combined ops. 
 
     // Object parameters
+    ObjectKeyPrefix string          // A random prefix to be used for object keys to ensure uniqueness across runs
     ObjectSize uint64               // The size of the objects we read and write
     Seed uint64                     // A seed for any PRNGs in use. 
     GeneratorType string            // Which type of Generator we will use to create and verify object data.

--- a/src/sibench/rbd_connecton.go
+++ b/src/sibench/rbd_connecton.go
@@ -71,7 +71,7 @@ func (conn *RbdConnection) WorkerConnect() error {
     // use.  The connection protocol map know how much data we will be managing.
 
     imageSize := uint64((conn.worker.WorkerRangeEnd - conn.worker.WorkerRangeStart) * conn.worker.ObjectSize)
-    imageName := fmt.Sprintf("sibench-%v-%v", conn.worker.Hostname, conn.worker.WorkerId)
+    imageName := fmt.Sprintf("%v-%v-%v", conn.protocol["image_prefix"], conn.worker.Hostname, conn.worker.WorkerId)
     imageOrder := uint64(22) // 1 << 22 gives a 4MB object size
 
     options := rbd.NewRbdImageOptions()

--- a/src/sibench/worker.go
+++ b/src/sibench/worker.go
@@ -272,7 +272,7 @@ func (w *Worker) connect() {
 
 
 func (w *Worker) writeOrPrepare(phase StatPhase) {
-    key := fmt.Sprintf("obj_%v", w.objectIndex)
+    key := fmt.Sprintf("%v-%v", w.order.ObjectKeyPrefix, w.objectIndex)
     contents := w.generator.Generate(w.order.ObjectSize, key, w.cycle)
     conn := w.connections[w.connIndex]
 
@@ -350,7 +350,7 @@ func (w *Worker) prepare() {
 func (w *Worker) read() {
     w.limitBandwidth()
 
-    key := fmt.Sprintf("obj_%v", w.objectIndex)
+    key := fmt.Sprintf("%v-%v", w.order.ObjectKeyPrefix, w.objectIndex)
     conn := w.connections[w.connIndex]
 
     var err error


### PR DESCRIPTION
Added a unique-per-run randomly generated prefix to object IDs so that new runs won't overwrite old data