### PR TITLE
Publish documentation on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Publish GitHub pages
+on:
+  push:
+    branches:
+      - master
+permissions:
+  contents: write
+jobs:
+  build-docs-and-publish:
+    runs-on: "ubuntu-20.04"
+    container:
+      image: debian:bullseye
+    steps:
+      - name: Install git before checkout
+        run: apt-get update && apt-get install -y git
+
+      - name: Install rsync for "github-pages-deploy-action" to work
+        run: apt-get install -y rsync
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies and build documentation
+        run: |
+          apt-get install -y python3-pip make
+          cd docs
+          pip3 install -r requirements.txt
+          make html
+          touch build/html/.nojekyll
+
+      - name: Deploy pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/build/html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  build:
+  build-release:
     name: Release build for amd64
     runs-on: "ubuntu-20.04"
     container:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+furo
+sphinx-tabs


### PR DESCRIPTION
This way we can deprecate the current infrastructure we have in place to publish the docs.