### PR TITLE
Fix sibench version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   build-release:
     name: Release build for amd64
     runs-on: "ubuntu-20.04"
+    permissions:
+      contents: write
     container:
       image: debian:bullseye
 
@@ -42,17 +44,13 @@ jobs:
         run:  make
 
       - name: tar the release
-        run: cd bin && tar -cvzf sibench-amd64.tar.gz sibench
+        run: cd bin && tar -cvzf sibench-amd64-${{ github.event.release.tag_name }}.tar.gz sibench
 
       - name: Upload sibench binary
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/bin/sibench-amd64.tar.gz
-          asset_name: sibench-amd64-${{ github.event.release.tag_name }}.tar.gz
-          asset_content_type: application/gzip
+          files: |
+            bin/sibench-amd64-${{ github.event.release.tag_name }}.tar.gz
 
   build-and-push-image:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Fix tag
+        # Workaround actions/checkout bug
+        # https://github.com/actions/checkout/issues/290
+        # https://github.com/actions/checkout/issues/882
+        run: |
+             git config --global --add safe.directory '*'
+             git fetch -fv origin tag "${GITHUB_REF_NAME}"
+
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18.6'
@@ -58,6 +67,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Fix tag
+        # Workaround actions/checkout bug
+        # https://github.com/actions/checkout/issues/290
+        # https://github.com/actions/checkout/issues/882
+        run: |
+             git config --global --add safe.directory '*'
+             git fetch -fv origin tag "${GITHUB_REF_NAME}"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Due to some issues on how GitHub Action `checkout` checks out the code, `git describe` won't generate the right version number when building `sibench`

These changes work around the issue.

Additionally stop using an unmaintained Action to upload release assets.