### PR TITLE
Catch error on large writes instead of failing on all large writes

### DIFF
--- a/src/sibench/file_connection_base.go
+++ b/src/sibench/file_connection_base.go
@@ -113,7 +113,7 @@ func (conn *FileConnectionBase) PutObject(key string, id uint64, buffer []byte) 
 
     for len(buffer) > 0 {
         n, err := fd.Write(buffer)
-        if err == nil {
+        if err != nil {
             return err
         }
 


### PR DESCRIPTION
Sibench was failing on large files (10MB+) due to this incorrect error handling.