### PR TITLE
Make sure we fetch tags when cloning the repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: 'master'
 
       - name: Install dependencies and build documentation


### PR DESCRIPTION
We need this for the docs to render correctly given they use `git describe`