### PR TITLE
Release 1.1.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+sibench (1.1.7) buster; urgency=low
+  [ Stephen Howell ]
+  * Prevent error when writes less than the size of the buffer occur.
 sibench (1.1.6) buster; urgency=low
   [ Stephen Howell ]
   * Prevent error when writing large files taking more than one IO operation

--- a/src/sibench/file_connection_base.go
+++ b/src/sibench/file_connection_base.go
@@ -10,6 +10,8 @@ import "logger"
 import "os"
 import "strings"
 import "syscall"
+import "errors"
+import "io"
 
 
 /* 
@@ -113,7 +115,7 @@ func (conn *FileConnectionBase) PutObject(key string, id uint64, buffer []byte) 
 
     for len(buffer) > 0 {
         n, err := fd.Write(buffer)
-        if err != nil {
+        if (err != nil) && (!errors.Is(err, io.ErrShortWrite)) {
             return err
         }
 


### PR DESCRIPTION
After allowing large writes to work without error we discovered that partial writes in Go throw an error as normal practice, this change ensures that partial writes can succeed and these errors (and only this type of error) is treated as normal and does not halt execution.